### PR TITLE
change ssh pubkey type

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,7 @@ resource "yandex_compute_instance" "vps" {
   }
 
   metadata = {
-    ssh-keys            = "${var.ssh_username}:${file(var.ssh_pubkey)}"
+    ssh-keys            = var.ssh_pubkey != "" ? "${var.ssh_username}:${var.ssh_pubkey}" : null
     serial-port-enable  = var.serial-port-enable != null ? var.serial-port-enable : null
     user-data           = local.rendered-cloud-init-file
   }

--- a/variables.tf
+++ b/variables.tf
@@ -79,7 +79,7 @@ variable "ssh_username" {
 variable "ssh_pubkey" {
   description = "SSH public key for access to the instance"
   type        = string
-  default     = "~/.ssh/id_rsa.pub"
+  default     = ""
 }
 
 variable "serial-port-enable" {


### PR DESCRIPTION
Changing the type of ssh key
previously passed the path to the file, but now it is necessary to pass the key content directly.